### PR TITLE
test: add unit tests for aggregation services

### DIFF
--- a/src/mcp/prompt-aggregation-service.test.ts
+++ b/src/mcp/prompt-aggregation-service.test.ts
@@ -1,0 +1,472 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TestBed } from "@suites/unit";
+import { PromptAggregationService } from "./prompt-aggregation-service.js";
+import { TYPES } from "../types/index.js";
+import type { MCPClientSession } from "./client-session.js";
+import type {
+  Prompt,
+  GetPromptResult,
+} from "@modelcontextprotocol/sdk/types.js";
+
+describe("PromptAggregationService", () => {
+  let service: PromptAggregationService;
+  let mockClientManager: ReturnType<typeof unitRef.get>;
+  let mockLogger: ReturnType<typeof unitRef.get>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let unitRef: any;
+
+  beforeEach(async () => {
+    const { unit, unitRef: ref } = await TestBed.solitary(
+      PromptAggregationService,
+    ).compile();
+    service = unit;
+    unitRef = ref;
+    mockClientManager = unitRef.get(TYPES.MCPClientManager);
+    mockLogger = unitRef.get(TYPES.Logger);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listPrompts", () => {
+    it("should aggregate prompts from multiple servers", async () => {
+      const server1Prompts: Prompt[] = [
+        { name: "prompt1", description: "First prompt" },
+        { name: "prompt2", description: "Second prompt" },
+      ];
+      const server2Prompts: Prompt[] = [
+        { name: "promptA", description: "Prompt A" },
+      ];
+
+      const mockClient1 = createMockClientSession({ prompts: server1Prompts });
+      const mockClient2 = createMockClientSession({ prompts: server2Prompts });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient1 as unknown as MCPClientSession],
+        ["server2", mockClient2 as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listPrompts("session-123");
+
+      expect(result.prompts).toHaveLength(3);
+      expect(result.prompts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "server1/prompt1" }),
+          expect.objectContaining({ name: "server1/prompt2" }),
+          expect.objectContaining({ name: "server2/promptA" }),
+        ]),
+      );
+    });
+
+    it("should return empty array when no clients available", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listPrompts("session-123");
+
+      expect(result.prompts).toEqual([]);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "No clients available for session 'session-123'",
+      );
+    });
+
+    it("should use 'default' session when sessionId is empty", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.listPrompts("");
+
+      expect(mockClientManager.getClientsBySession).toHaveBeenCalledWith(
+        "default",
+      );
+    });
+
+    it("should cache results and return cached prompts on subsequent calls", async () => {
+      const serverPrompts: Prompt[] = [{ name: "cached-prompt" }];
+      const mockClient = createMockClientSession({ prompts: serverPrompts });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      // First call - should fetch from clients
+      const result1 = await service.listPrompts("session-123");
+
+      // Second call - should return cached
+      const result2 = await service.listPrompts("session-123");
+
+      expect(mockClient.listPrompts).toHaveBeenCalledTimes(1);
+      expect(result1).toEqual(result2);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "Returning cached prompt list for session 'session-123'",
+      );
+    });
+
+    it("should handle server errors gracefully and continue aggregation", async () => {
+      const workingPrompts: Prompt[] = [{ name: "working-prompt" }];
+      const mockWorkingClient = createMockClientSession({
+        prompts: workingPrompts,
+      });
+      const mockFailingClient = createMockClientSession({});
+      mockFailingClient.listPrompts.mockRejectedValue(
+        new Error("Connection lost"),
+      );
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["working-server", mockWorkingClient as unknown as MCPClientSession],
+        ["failing-server", mockFailingClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listPrompts("session-123");
+
+      expect(result.prompts).toHaveLength(1);
+      expect(result.prompts[0]!.name).toBe("working-server/working-prompt");
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to list prompts from server 'failing-server':",
+        expect.any(Error),
+      );
+    });
+
+    it("should silently ignore 'Server does not support prompts' errors", async () => {
+      const mockClient = createMockClientSession({});
+      mockClient.listPrompts.mockRejectedValue(
+        new Error("Server does not support prompts"),
+      );
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["no-prompts-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listPrompts("session-123");
+
+      expect(result.prompts).toEqual([]);
+      // Should NOT log error for this specific case
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("should namespace prompts with server name prefix", async () => {
+      const serverPrompts: Prompt[] = [
+        { name: "my-prompt", description: "A prompt", arguments: [] },
+      ];
+      const mockClient = createMockClientSession({ prompts: serverPrompts });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["my-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listPrompts("session-123");
+
+      expect(result.prompts[0]).toEqual({
+        name: "my-server/my-prompt",
+        description: "A prompt",
+        arguments: [],
+      });
+    });
+
+    it("should log aggregation info after successful fetch", async () => {
+      const serverPrompts: Prompt[] = [{ name: "p1" }, { name: "p2" }];
+      const mockClient = createMockClientSession({ prompts: serverPrompts });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.listPrompts("session-123");
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "Aggregated 2 prompts from 1 servers for session 'session-123'",
+      );
+    });
+
+    it("should handle concurrent prompt fetches from multiple servers", async () => {
+      const prompts1: Prompt[] = [{ name: "prompt1" }];
+      const prompts2: Prompt[] = [{ name: "prompt2" }];
+      const prompts3: Prompt[] = [{ name: "prompt3" }];
+
+      const mockClient1 = createMockClientSession({ prompts: prompts1 });
+      const mockClient2 = createMockClientSession({ prompts: prompts2 });
+      const mockClient3 = createMockClientSession({ prompts: prompts3 });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient1 as unknown as MCPClientSession],
+        ["server2", mockClient2 as unknown as MCPClientSession],
+        ["server3", mockClient3 as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listPrompts("session-123");
+
+      expect(result.prompts).toHaveLength(3);
+      expect(mockClient1.listPrompts).toHaveBeenCalled();
+      expect(mockClient2.listPrompts).toHaveBeenCalled();
+      expect(mockClient3.listPrompts).toHaveBeenCalled();
+    });
+  });
+
+  describe("getPrompt", () => {
+    it("should retrieve a prompt from the correct server", async () => {
+      const mockResult: GetPromptResult = {
+        description: "Retrieved prompt",
+        messages: [{ role: "user", content: { type: "text", text: "Hello" } }],
+      };
+      const mockClient = createMockClientSession({ promptResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["my-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.getPrompt(
+        "my-server/my-prompt",
+        { arg1: "value1" },
+        "session-123",
+      );
+
+      expect(mockClient.getPrompt).toHaveBeenCalledWith({
+        name: "my-prompt",
+        arguments: { arg1: "value1" },
+      });
+      expect(result.description).toBe("Retrieved prompt");
+    });
+
+    it("should throw error for invalid prompt name format", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.getPrompt("invalid-name-no-slash", undefined, "session-123"),
+      ).rejects.toThrow(
+        "Invalid prompt name format: 'invalid-name-no-slash'. Expected format: {server-name}/{prompt-name}",
+      );
+    });
+
+    it("should throw error when server not found", async () => {
+      const mockClient = createMockClientSession({});
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["other-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.getPrompt("unknown-server/my-prompt", undefined, "session-123"),
+      ).rejects.toThrow(
+        "Server 'unknown-server' not found in session 'session-123'. Available servers: other-server",
+      );
+    });
+
+    it("should throw error when no servers available", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.getPrompt("unknown-server/my-prompt", undefined, "session-123"),
+      ).rejects.toThrow("Available servers: none");
+    });
+
+    it("should use 'default' session when sessionId is empty", async () => {
+      const mockResult: GetPromptResult = {
+        messages: [],
+      };
+      const mockClient = createMockClientSession({ promptResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.getPrompt("server1/prompt1", undefined, "");
+
+      expect(mockClientManager.getClientsBySession).toHaveBeenCalledWith(
+        "default",
+      );
+    });
+
+    it("should pass undefined arguments when not provided", async () => {
+      const mockResult: GetPromptResult = { messages: [] };
+      const mockClient = createMockClientSession({ promptResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.getPrompt("server1/prompt1", undefined, "session-123");
+
+      expect(mockClient.getPrompt).toHaveBeenCalledWith({
+        name: "prompt1",
+        arguments: undefined,
+      });
+    });
+
+    it("should log debug message on successful retrieval", async () => {
+      const mockResult: GetPromptResult = { messages: [] };
+      const mockClient = createMockClientSession({ promptResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.getPrompt("server1/my-prompt", undefined, "session-123");
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "Got prompt 'my-prompt' from server 'server1'",
+      );
+    });
+
+    it("should re-throw and log error when getPrompt fails", async () => {
+      const mockClient = createMockClientSession({});
+      mockClient.getPrompt.mockRejectedValue(new Error("Prompt not found"));
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.getPrompt("server1/missing-prompt", undefined, "session-123"),
+      ).rejects.toThrow("Prompt not found");
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to get prompt 'missing-prompt' from server 'server1':",
+        expect.any(Error),
+      );
+    });
+
+    it("should handle prompt names with multiple slashes", async () => {
+      const mockResult: GetPromptResult = { messages: [] };
+      const mockClient = createMockClientSession({ promptResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.getPrompt(
+        "server1/nested/prompt/name",
+        undefined,
+        "session-123",
+      );
+
+      // The first slash separates server from prompt name, rest is part of prompt name
+      expect(mockClient.getPrompt).toHaveBeenCalledWith({
+        name: "nested/prompt/name",
+        arguments: undefined,
+      });
+    });
+
+    it("should throw error for empty server name", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.getPrompt("/prompt-only", undefined, "session-123"),
+      ).rejects.toThrow("Invalid prompt name format");
+    });
+
+    it("should throw error for empty prompt name", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.getPrompt("server-only/", undefined, "session-123"),
+      ).rejects.toThrow("Invalid prompt name format");
+    });
+  });
+
+  describe("handlePromptListChanged", () => {
+    it("should invalidate cache for the session", async () => {
+      const serverPrompts: Prompt[] = [{ name: "cached-prompt" }];
+      const mockClient = createMockClientSession({ prompts: serverPrompts });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      // Populate cache
+      await service.listPrompts("session-123");
+      expect(mockClient.listPrompts).toHaveBeenCalledTimes(1);
+
+      // Invalidate cache
+      service.handlePromptListChanged("server1", "session-123");
+
+      // Should fetch again after invalidation
+      await service.listPrompts("session-123");
+      expect(mockClient.listPrompts).toHaveBeenCalledTimes(2);
+    });
+
+    it("should log cache invalidation", () => {
+      service.handlePromptListChanged("server1", "session-123");
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "Prompt list changed for server 'server1' in session 'session-123'",
+      );
+    });
+
+    it("should not affect other session caches", async () => {
+      const serverPrompts: Prompt[] = [{ name: "prompt1" }];
+      const mockClient = createMockClientSession({ prompts: serverPrompts });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      // Populate cache for two sessions
+      await service.listPrompts("session-A");
+      await service.listPrompts("session-B");
+
+      // Invalidate only session-A
+      service.handlePromptListChanged("server1", "session-A");
+
+      // Fetch again - session-B should still be cached
+      await service.listPrompts("session-B");
+
+      // session-A was fetched once, then invalidated, so still 1 call for session-A
+      // session-B was fetched once and cached, so still just 1 additional call
+      // Total: 2 calls during initial population (one per session)
+      // After invalidation: session-B returns cached, no new call
+      expect(mockClient.listPrompts).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+// Helper function to create mock client sessions
+function createMockClientSession(options: {
+  prompts?: Prompt[];
+  promptResult?: GetPromptResult;
+}): {
+  listPrompts: ReturnType<typeof vi.fn>;
+  getPrompt: ReturnType<typeof vi.fn>;
+} {
+  return {
+    listPrompts: vi.fn().mockResolvedValue(options.prompts ?? []),
+    getPrompt: vi
+      .fn()
+      .mockResolvedValue(options.promptResult ?? { messages: [] }),
+  };
+}

--- a/src/mcp/resource-aggregation-service.test.ts
+++ b/src/mcp/resource-aggregation-service.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TestBed } from "@suites/unit";
+import { ResourceAggregationService } from "./resource-aggregation-service.js";
+import { TYPES } from "../types/index.js";
+import type { MCPClientSession } from "./client-session.js";
+import type {
+  Resource,
+  ReadResourceResult,
+} from "@modelcontextprotocol/sdk/types.js";
+
+describe("ResourceAggregationService", () => {
+  let service: ResourceAggregationService;
+  let mockClientManager: ReturnType<typeof unitRef.get>;
+  let mockLogger: ReturnType<typeof unitRef.get>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let unitRef: any;
+
+  beforeEach(async () => {
+    const { unit, unitRef: ref } = await TestBed.solitary(
+      ResourceAggregationService,
+    ).compile();
+    service = unit;
+    unitRef = ref;
+    mockClientManager = unitRef.get(TYPES.MCPClientManager);
+    mockLogger = unitRef.get(TYPES.Logger);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listResources", () => {
+    it("should aggregate resources from multiple servers", async () => {
+      const server1Resources: Resource[] = [
+        { uri: "file:///doc1.md", name: "Doc 1" },
+        { uri: "file:///doc2.md", name: "Doc 2" },
+      ];
+      const server2Resources: Resource[] = [
+        { uri: "http://api/data", name: "API Data" },
+      ];
+
+      const mockClient1 = createMockClientSession({
+        resources: server1Resources,
+      });
+      const mockClient2 = createMockClientSession({
+        resources: server2Resources,
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient1 as unknown as MCPClientSession],
+        ["server2", mockClient2 as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listResources("session-123");
+
+      expect(result.resources).toHaveLength(3);
+      expect(result.resources).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ uri: "mcp://server1/file:///doc1.md" }),
+          expect.objectContaining({ uri: "mcp://server1/file:///doc2.md" }),
+          expect.objectContaining({ uri: "mcp://server2/http://api/data" }),
+        ]),
+      );
+    });
+
+    it("should return empty array when no clients available", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listResources("session-123");
+
+      expect(result.resources).toEqual([]);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "No clients available for session 'session-123'",
+      );
+    });
+
+    it("should use 'default' session when sessionId is empty", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.listResources("");
+
+      expect(mockClientManager.getClientsBySession).toHaveBeenCalledWith(
+        "default",
+      );
+    });
+
+    it("should cache results and return cached resources on subsequent calls", async () => {
+      const serverResources: Resource[] = [
+        { uri: "file:///cached.txt", name: "Cached" },
+      ];
+      const mockClient = createMockClientSession({
+        resources: serverResources,
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      // First call - should fetch from clients
+      const result1 = await service.listResources("session-123");
+
+      // Second call - should return cached
+      const result2 = await service.listResources("session-123");
+
+      expect(mockClient.listResources).toHaveBeenCalledTimes(1);
+      expect(result1).toEqual(result2);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "Returning cached resource list for session 'session-123'",
+      );
+    });
+
+    it("should handle server errors gracefully and continue aggregation", async () => {
+      const workingResources: Resource[] = [
+        { uri: "file:///working.txt", name: "Working" },
+      ];
+      const mockWorkingClient = createMockClientSession({
+        resources: workingResources,
+      });
+      const mockFailingClient = createMockClientSession({});
+      mockFailingClient.listResources.mockRejectedValue(
+        new Error("Connection lost"),
+      );
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["working-server", mockWorkingClient as unknown as MCPClientSession],
+        ["failing-server", mockFailingClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listResources("session-123");
+
+      expect(result.resources).toHaveLength(1);
+      expect(result.resources[0]!.uri).toBe(
+        "mcp://working-server/file:///working.txt",
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to list resources from server 'failing-server':",
+        expect.any(Error),
+      );
+    });
+
+    it("should silently ignore 'Server does not support resources' errors", async () => {
+      const mockClient = createMockClientSession({});
+      mockClient.listResources.mockRejectedValue(
+        new Error("Server does not support resources"),
+      );
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["no-resources-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listResources("session-123");
+
+      expect(result.resources).toEqual([]);
+      // Should NOT log error for this specific case
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it("should namespace resources with mcp:// URI format", async () => {
+      const serverResources: Resource[] = [
+        {
+          uri: "file:///path/to/file.txt",
+          name: "My File",
+          description: "A file",
+          mimeType: "text/plain",
+        },
+      ];
+      const mockClient = createMockClientSession({
+        resources: serverResources,
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["my-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listResources("session-123");
+
+      expect(result.resources[0]).toEqual({
+        uri: "mcp://my-server/file:///path/to/file.txt",
+        name: "My File",
+        description: "A file",
+        mimeType: "text/plain",
+      });
+    });
+
+    it("should log aggregation info after successful fetch", async () => {
+      const serverResources: Resource[] = [
+        { uri: "res1", name: "R1" },
+        { uri: "res2", name: "R2" },
+      ];
+      const mockClient = createMockClientSession({
+        resources: serverResources,
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.listResources("session-123");
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "Aggregated 2 resources from 1 servers for session 'session-123'",
+      );
+    });
+
+    it("should handle concurrent resource fetches from multiple servers", async () => {
+      const resources1: Resource[] = [{ uri: "r1", name: "R1" }];
+      const resources2: Resource[] = [{ uri: "r2", name: "R2" }];
+      const resources3: Resource[] = [{ uri: "r3", name: "R3" }];
+
+      const mockClient1 = createMockClientSession({ resources: resources1 });
+      const mockClient2 = createMockClientSession({ resources: resources2 });
+      const mockClient3 = createMockClientSession({ resources: resources3 });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient1 as unknown as MCPClientSession],
+        ["server2", mockClient2 as unknown as MCPClientSession],
+        ["server3", mockClient3 as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listResources("session-123");
+
+      expect(result.resources).toHaveLength(3);
+      expect(mockClient1.listResources).toHaveBeenCalled();
+      expect(mockClient2.listResources).toHaveBeenCalled();
+      expect(mockClient3.listResources).toHaveBeenCalled();
+    });
+  });
+
+  describe("readResource", () => {
+    it("should read a resource from the correct server", async () => {
+      const mockResult: ReadResourceResult = {
+        contents: [
+          {
+            uri: "file:///doc.md",
+            mimeType: "text/markdown",
+            text: "# Hello World",
+          },
+        ],
+      };
+      const mockClient = createMockClientSession({ readResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["my-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.readResource(
+        "mcp://my-server/file:///doc.md",
+        "session-123",
+      );
+
+      expect(mockClient.readResource).toHaveBeenCalledWith({
+        uri: "file:///doc.md",
+      });
+      expect(result.contents).toHaveLength(1);
+      expect(result.contents[0]!.uri).toBe("mcp://my-server/file:///doc.md");
+    });
+
+    it("should throw error for invalid URI format - missing mcp prefix", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.readResource("http://example.com/resource", "session-123"),
+      ).rejects.toThrow(
+        "Invalid resource URI format: 'http://example.com/resource'. Expected format: mcp://{server-name}/{uri}",
+      );
+    });
+
+    it("should throw error for invalid URI format - no slash after server", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.readResource("mcp://server-only", "session-123"),
+      ).rejects.toThrow("Invalid resource URI format");
+    });
+
+    it("should throw error when server not found", async () => {
+      const mockClient = createMockClientSession({});
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["other-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.readResource(
+          "mcp://unknown-server/file:///doc.md",
+          "session-123",
+        ),
+      ).rejects.toThrow(
+        "Server 'unknown-server' not found in session 'session-123'. Available servers: other-server",
+      );
+    });
+
+    it("should throw error when no servers available", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.readResource("mcp://unknown/file:///doc.md", "session-123"),
+      ).rejects.toThrow("Available servers: none");
+    });
+
+    it("should use 'default' session when sessionId is empty", async () => {
+      const mockResult: ReadResourceResult = {
+        contents: [{ uri: "file:///doc.md", text: "content" }],
+      };
+      const mockClient = createMockClientSession({ readResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.readResource("mcp://server1/file:///doc.md", "");
+
+      expect(mockClientManager.getClientsBySession).toHaveBeenCalledWith(
+        "default",
+      );
+    });
+
+    it("should namespace URIs in all content blocks", async () => {
+      const mockResult: ReadResourceResult = {
+        contents: [
+          { uri: "file:///doc1.md", text: "Content 1" },
+          { uri: "file:///doc2.md", text: "Content 2" },
+        ],
+      };
+      const mockClient = createMockClientSession({ readResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.readResource(
+        "mcp://server1/file:///doc1.md",
+        "session-123",
+      );
+
+      expect(result.contents[0]!.uri).toBe("mcp://server1/file:///doc1.md");
+      expect(result.contents[1]!.uri).toBe("mcp://server1/file:///doc2.md");
+    });
+
+    it("should log debug message on successful read", async () => {
+      const mockResult: ReadResourceResult = {
+        contents: [{ uri: "file:///doc.md", text: "content" }],
+      };
+      const mockClient = createMockClientSession({ readResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.readResource(
+        "mcp://server1/file:///my-doc.md",
+        "session-123",
+      );
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "Read resource 'file:///my-doc.md' from server 'server1'",
+      );
+    });
+
+    it("should re-throw and log error when readResource fails", async () => {
+      const mockClient = createMockClientSession({});
+      mockClient.readResource.mockRejectedValue(
+        new Error("Resource not found"),
+      );
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.readResource("mcp://server1/file:///missing.md", "session-123"),
+      ).rejects.toThrow("Resource not found");
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to read resource 'file:///missing.md' from server 'server1':",
+        expect.any(Error),
+      );
+    });
+
+    it("should handle URIs with complex paths", async () => {
+      const mockResult: ReadResourceResult = {
+        contents: [
+          { uri: "file:///path/to/nested/file.txt", text: "nested content" },
+        ],
+      };
+      const mockClient = createMockClientSession({ readResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await service.readResource(
+        "mcp://server1/file:///path/to/nested/file.txt",
+        "session-123",
+      );
+
+      expect(mockClient.readResource).toHaveBeenCalledWith({
+        uri: "file:///path/to/nested/file.txt",
+      });
+    });
+
+    it("should preserve other fields in read result", async () => {
+      const mockResult: ReadResourceResult = {
+        contents: [
+          {
+            uri: "file:///doc.md",
+            mimeType: "text/markdown",
+            text: "# Hello",
+          },
+        ],
+      };
+      const mockClient = createMockClientSession({ readResult: mockResult });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.readResource(
+        "mcp://server1/file:///doc.md",
+        "session-123",
+      );
+
+      expect(result.contents[0]!.mimeType).toBe("text/markdown");
+      expect((result.contents[0] as { text: string }).text).toBe("# Hello");
+    });
+
+    it("should throw error for empty server name in URI", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.readResource("mcp:///file:///doc.md", "session-123"),
+      ).rejects.toThrow("Invalid resource URI format");
+    });
+
+    it("should throw error for empty resource URI part", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      await expect(
+        service.readResource("mcp://server1/", "session-123"),
+      ).rejects.toThrow("Invalid resource URI format");
+    });
+  });
+
+  describe("handleResourceListChanged", () => {
+    it("should invalidate cache for the session", async () => {
+      const serverResources: Resource[] = [
+        { uri: "cached.txt", name: "Cached" },
+      ];
+      const mockClient = createMockClientSession({
+        resources: serverResources,
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      // Populate cache
+      await service.listResources("session-123");
+      expect(mockClient.listResources).toHaveBeenCalledTimes(1);
+
+      // Invalidate cache
+      service.handleResourceListChanged("server1", "session-123");
+
+      // Should fetch again after invalidation
+      await service.listResources("session-123");
+      expect(mockClient.listResources).toHaveBeenCalledTimes(2);
+    });
+
+    it("should log cache invalidation", () => {
+      service.handleResourceListChanged("server1", "session-123");
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "Resource list changed for server 'server1' in session 'session-123'",
+      );
+    });
+
+    it("should not affect other session caches", async () => {
+      const serverResources: Resource[] = [{ uri: "r1", name: "R1" }];
+      const mockClient = createMockClientSession({
+        resources: serverResources,
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      // Populate cache for two sessions
+      await service.listResources("session-A");
+      await service.listResources("session-B");
+
+      // Invalidate only session-A
+      service.handleResourceListChanged("server1", "session-A");
+
+      // Fetch again - session-B should still be cached
+      await service.listResources("session-B");
+
+      // Total calls: 2 during initial population (one per session)
+      // After invalidation: session-B returns cached, no new call
+      expect(mockClient.listResources).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+// Helper function to create mock client sessions
+function createMockClientSession(options: {
+  resources?: Resource[];
+  readResult?: ReadResourceResult;
+}): {
+  listResources: ReturnType<typeof vi.fn>;
+  readResource: ReturnType<typeof vi.fn>;
+} {
+  return {
+    listResources: vi.fn().mockResolvedValue(options.resources ?? []),
+    readResource: vi
+      .fn()
+      .mockResolvedValue(options.readResult ?? { contents: [] }),
+  };
+}

--- a/src/mcp/tool-discovery-service.test.ts
+++ b/src/mcp/tool-discovery-service.test.ts
@@ -1,0 +1,897 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TestBed } from "@suites/unit";
+import { ToolDiscoveryService } from "./tool-discovery-service.js";
+import { TYPES } from "../types/index.js";
+import type { MCPClientSession } from "./client-session.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+describe("ToolDiscoveryService", () => {
+  let service: ToolDiscoveryService;
+  let mockClientManager: ReturnType<typeof unitRef.get>;
+  let mockLogger: ReturnType<typeof unitRef.get>;
+  let mockFormatter: ReturnType<typeof unitRef.get>;
+  let mockLuaRuntime: ReturnType<typeof unitRef.get>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let unitRef: any;
+
+  beforeEach(async () => {
+    const { unit, unitRef: ref } =
+      await TestBed.solitary(ToolDiscoveryService).compile();
+    service = unit;
+    unitRef = ref;
+    mockClientManager = unitRef.get(TYPES.MCPClientManager);
+    mockLogger = unitRef.get(TYPES.Logger);
+    mockFormatter = unitRef.get(TYPES.MCPFormatterService);
+    mockLuaRuntime = unitRef.get(TYPES.LuaRuntime);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listServers", () => {
+    it("should return formatted list of connected servers", async () => {
+      const mockClient = createMockClientSession({
+        serverVersion: { name: "test-server", version: "1.0.0" },
+        instructions: "Test instructions",
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+      const failedServersMap = new Map<string, string>();
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockClientManager.getFailedServers.mockReturnValue(failedServersMap);
+      mockFormatter.formatServerList.mockReturnValue("Formatted server list");
+
+      const result = await service.listServers("session-123");
+
+      expect(mockClientManager.getClientsBySession).toHaveBeenCalledWith(
+        "session-123",
+      );
+      expect(mockFormatter.formatServerList).toHaveBeenCalledWith(
+        "session-123",
+        expect.arrayContaining([
+          expect.objectContaining({
+            luaIdentifier: "server1",
+            serverInfo: expect.objectContaining({
+              name: "test-server",
+              version: "1.0.0",
+            }),
+          }),
+        ]),
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Formatted server list" }],
+      });
+    });
+
+    it("should use 'default' session when sessionId is empty", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      const failedServersMap = new Map<string, string>();
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockClientManager.getFailedServers.mockReturnValue(failedServersMap);
+      mockFormatter.formatServerList.mockReturnValue("Empty list");
+
+      await service.listServers("");
+
+      expect(mockClientManager.getClientsBySession).toHaveBeenCalledWith(
+        "default",
+      );
+      expect(mockFormatter.formatServerList).toHaveBeenCalledWith(
+        "default",
+        [],
+      );
+    });
+
+    it("should include failed servers with error status", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+      const failedServersMap = new Map<string, string>([
+        ["failed-server", "Connection refused"],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockClientManager.getFailedServers.mockReturnValue(failedServersMap);
+      mockFormatter.formatServerList.mockReturnValue("List with failed server");
+
+      await service.listServers("session-123");
+
+      expect(mockFormatter.formatServerList).toHaveBeenCalledWith(
+        "session-123",
+        expect.arrayContaining([
+          expect.objectContaining({
+            luaIdentifier: "failed_server",
+            error: "Connection failed",
+          }),
+        ]),
+      );
+    });
+
+    it("should sanitize server names for Lua identifiers", async () => {
+      const mockClient = createMockClientSession({
+        serverVersion: { name: "My Server" },
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["my-cool-server", mockClient as unknown as MCPClientSession],
+      ]);
+      const failedServersMap = new Map<string, string>();
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockClientManager.getFailedServers.mockReturnValue(failedServersMap);
+      mockFormatter.formatServerList.mockReturnValue("Formatted");
+
+      await service.listServers("session-123");
+
+      expect(mockFormatter.formatServerList).toHaveBeenCalledWith(
+        "session-123",
+        expect.arrayContaining([
+          expect.objectContaining({
+            luaIdentifier: "my_cool_server",
+          }),
+        ]),
+      );
+    });
+
+    it("should handle errors from getServerVersion gracefully", async () => {
+      const mockClient = createMockClientSession({});
+      mockClient.getServerVersion.mockImplementation(() => {
+        throw new Error("Version unavailable");
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["error-server", mockClient as unknown as MCPClientSession],
+      ]);
+      const failedServersMap = new Map<string, string>();
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockClientManager.getFailedServers.mockReturnValue(failedServersMap);
+      mockFormatter.formatServerList.mockReturnValue("List with error");
+
+      await service.listServers("session-123");
+
+      expect(mockLogger.error).toHaveBeenCalled();
+      expect(mockFormatter.formatServerList).toHaveBeenCalledWith(
+        "session-123",
+        expect.arrayContaining([
+          expect.objectContaining({
+            luaIdentifier: "error_server",
+            error: expect.stringContaining("Failed to retrieve server info"),
+          }),
+        ]),
+      );
+    });
+
+    it("should return error result when listServers throws", async () => {
+      mockClientManager.getClientsBySession.mockImplementation(() => {
+        throw new Error("Session not found");
+      });
+
+      const result = await service.listServers("invalid-session");
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Failed to list servers"),
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should handle instructions being unavailable", async () => {
+      const mockClient = createMockClientSession({
+        serverVersion: { name: "test-server" },
+      });
+      mockClient.getInstructions.mockImplementation(() => {
+        throw new Error("Instructions not available");
+      });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockClientManager.getFailedServers.mockReturnValue(new Map());
+      mockFormatter.formatServerList.mockReturnValue("Formatted");
+
+      await service.listServers("session-123");
+
+      expect(mockFormatter.formatServerList).toHaveBeenCalledWith(
+        "session-123",
+        expect.arrayContaining([
+          expect.objectContaining({
+            serverInfo: expect.objectContaining({
+              instructions: undefined,
+            }),
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe("listServerTools", () => {
+    it("should return formatted list of tools for a server", async () => {
+      const mockTools: Tool[] = [
+        {
+          name: "tool1",
+          description: "First tool",
+          inputSchema: { type: "object" },
+        },
+        {
+          name: "tool2",
+          description: "Second tool",
+          inputSchema: { type: "object" },
+        },
+      ];
+      const mockClient = createMockClientSession({ tools: mockTools });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["my_server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockFormatter.formatToolList.mockReturnValue("Formatted tool list");
+
+      const result = await service.listServerTools("my_server", "session-123");
+
+      expect(mockClient.listTools).toHaveBeenCalled();
+      expect(mockFormatter.formatToolList).toHaveBeenCalledWith("my_server", [
+        { luaName: "tool1", description: "First tool" },
+        { luaName: "tool2", description: "Second tool" },
+      ]);
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Formatted tool list" }],
+      });
+    });
+
+    it("should return error when server not found", async () => {
+      const clientsMap = new Map<string, MCPClientSession>([
+        [
+          "other_server",
+          createMockClientSession({}) as unknown as MCPClientSession,
+        ],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listServerTools(
+        "unknown_server",
+        "session-123",
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Server 'unknown_server' not found"),
+          },
+        ],
+        isError: true,
+      });
+      expect(result.content[0]).toHaveProperty(
+        "text",
+        expect.stringContaining("Available servers: other_server"),
+      );
+    });
+
+    it("should return error when no servers available", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listServerTools(
+        "unknown_server",
+        "session-123",
+      );
+
+      expect(result.content[0]).toHaveProperty(
+        "text",
+        expect.stringContaining("Available servers: none"),
+      );
+    });
+
+    it("should use default session when sessionId is empty", async () => {
+      const mockClient = createMockClientSession({ tools: [] });
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockFormatter.formatToolList.mockReturnValue("Formatted");
+
+      await service.listServerTools("server1", "");
+
+      expect(mockClientManager.getClientsBySession).toHaveBeenCalledWith(
+        "default",
+      );
+    });
+
+    it("should match server by sanitized Lua name", async () => {
+      const mockTools: Tool[] = [
+        {
+          name: "some-tool",
+          description: "A tool",
+          inputSchema: { type: "object" },
+        },
+      ];
+      const mockClient = createMockClientSession({ tools: mockTools });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["my-hyphenated-server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockFormatter.formatToolList.mockReturnValue("Formatted");
+
+      const result = await service.listServerTools(
+        "my_hyphenated_server",
+        "session-123",
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(mockClient.listTools).toHaveBeenCalled();
+    });
+
+    it("should handle tools with no description", async () => {
+      const mockTools: Tool[] = [
+        { name: "tool1", inputSchema: { type: "object" } }, // no description
+      ];
+      const mockClient = createMockClientSession({ tools: mockTools });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockFormatter.formatToolList.mockReturnValue("Formatted");
+
+      await service.listServerTools("server1", "session-123");
+
+      expect(mockFormatter.formatToolList).toHaveBeenCalledWith("server1", [
+        { luaName: "tool1", description: "" },
+      ]);
+    });
+
+    it("should return error result when listTools throws", async () => {
+      const mockClient = createMockClientSession({});
+      mockClient.listTools.mockRejectedValue(new Error("Connection lost"));
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.listServerTools("server1", "session-123");
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Failed to list tools"),
+          },
+        ],
+        isError: true,
+      });
+    });
+  });
+
+  describe("getToolDetails", () => {
+    it("should return formatted tool details", async () => {
+      const mockTool: Tool = {
+        name: "my-tool",
+        description: "Tool description",
+        inputSchema: { type: "object", properties: {} },
+      };
+      const mockClient = createMockClientSession({ tools: [mockTool] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockFormatter.formatToolDetails.mockReturnValue("Formatted tool details");
+
+      const result = await service.getToolDetails(
+        "server1",
+        "my_tool",
+        "session-123",
+      );
+
+      expect(mockFormatter.formatToolDetails).toHaveBeenCalledWith(
+        "server1",
+        "my_tool",
+        mockTool,
+      );
+      expect(result).toEqual({
+        content: [{ type: "text", text: "Formatted tool details" }],
+      });
+    });
+
+    it("should return error when server not found", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.getToolDetails(
+        "unknown_server",
+        "tool1",
+        "session-123",
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Server 'unknown_server' not found"),
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should return error when tool not found", async () => {
+      const mockTools: Tool[] = [
+        {
+          name: "other-tool",
+          description: "Other",
+          inputSchema: { type: "object" },
+        },
+      ];
+      const mockClient = createMockClientSession({ tools: mockTools });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.getToolDetails(
+        "server1",
+        "unknown_tool",
+        "session-123",
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Tool 'unknown_tool' not found"),
+          },
+        ],
+        isError: true,
+      });
+      expect(result.content[0]).toHaveProperty(
+        "text",
+        expect.stringContaining("Available tools: other_tool"),
+      );
+    });
+
+    it("should match tool by sanitized Lua name", async () => {
+      const mockTool: Tool = {
+        name: "my-hyphenated-tool",
+        description: "A tool",
+        inputSchema: { type: "object" },
+      };
+      const mockClient = createMockClientSession({ tools: [mockTool] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockFormatter.formatToolDetails.mockReturnValue("Formatted");
+
+      const result = await service.getToolDetails(
+        "server1",
+        "my_hyphenated_tool",
+        "session-123",
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(mockFormatter.formatToolDetails).toHaveBeenCalled();
+    });
+
+    it("should return error when no tools available on server", async () => {
+      const mockClient = createMockClientSession({ tools: [] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.getToolDetails(
+        "server1",
+        "any_tool",
+        "session-123",
+      );
+
+      expect(result.content[0]).toHaveProperty(
+        "text",
+        expect.stringContaining("Available tools: none"),
+      );
+    });
+
+    it("should return error result when getToolDetails throws", async () => {
+      const mockClient = createMockClientSession({});
+      mockClient.listTools.mockRejectedValue(new Error("Connection error"));
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.getToolDetails(
+        "server1",
+        "tool1",
+        "session-123",
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Failed to get tool details"),
+          },
+        ],
+        isError: true,
+      });
+    });
+  });
+
+  describe("inspectToolResponse", () => {
+    it("should execute tool and return formatted response", async () => {
+      const mockTool: Tool = {
+        name: "test-tool",
+        description: "Test tool",
+        inputSchema: { type: "object" },
+      };
+      const mockClient = createMockClientSession({ tools: [mockTool] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockLuaRuntime.executeScript.mockResolvedValue({ result: "success" });
+
+      const result = await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { arg1: "value1" },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("server1.test_tool"),
+        clientsMap,
+      );
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0]).toHaveProperty(
+        "text",
+        expect.stringContaining("Tool executed"),
+      );
+      expect(result.content[0]).toHaveProperty(
+        "text",
+        expect.stringContaining('"result": "success"'),
+      );
+    });
+
+    it("should return error when server not found", async () => {
+      const clientsMap = new Map<string, MCPClientSession>();
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.inspectToolResponse(
+        "unknown_server",
+        "tool1",
+        {},
+        "session-123",
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Server 'unknown_server' not found"),
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should return error when tool not found", async () => {
+      const mockClient = createMockClientSession({ tools: [] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+
+      const result = await service.inspectToolResponse(
+        "server1",
+        "unknown_tool",
+        {},
+        "session-123",
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Tool 'unknown_tool' not found"),
+          },
+        ],
+        isError: true,
+      });
+    });
+
+    it("should include sample args in generated Lua script", async () => {
+      const mockTool: Tool = {
+        name: "calc",
+        description: "Calculator",
+        inputSchema: { type: "object" },
+      };
+      const mockClient = createMockClientSession({ tools: [mockTool] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["math_server", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockLuaRuntime.executeScript.mockResolvedValue(42);
+
+      await service.inspectToolResponse(
+        "math_server",
+        "calc",
+        { a: 10, b: 20 },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("a = 10"),
+        clientsMap,
+      );
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("b = 20"),
+        clientsMap,
+      );
+    });
+
+    it("should return error with warning when execution fails", async () => {
+      const mockTool: Tool = {
+        name: "failing-tool",
+        description: "Fails",
+        inputSchema: { type: "object" },
+      };
+      const mockClient = createMockClientSession({ tools: [mockTool] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockLuaRuntime.executeScript.mockRejectedValue(
+        new Error("Execution failed"),
+      );
+
+      const result = await service.inspectToolResponse(
+        "server1",
+        "failing_tool",
+        {},
+        "session-123",
+      );
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: "text",
+            text: expect.stringContaining("Failed to inspect tool response"),
+          },
+        ],
+        isError: true,
+      });
+      expect(result.content[0]).toHaveProperty(
+        "text",
+        expect.stringContaining("may have been executed"),
+      );
+    });
+
+    it("should log info and debug messages during execution", async () => {
+      const mockTool: Tool = {
+        name: "logged-tool",
+        description: "Logged",
+        inputSchema: { type: "object" },
+      };
+      const mockClient = createMockClientSession({ tools: [mockTool] });
+
+      const clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockLuaRuntime.executeScript.mockResolvedValue({});
+
+      await service.inspectToolResponse(
+        "server1",
+        "logged_tool",
+        { x: 1 },
+        "session-123",
+      );
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Inspecting tool response"),
+      );
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("Generated inspection script"),
+      );
+    });
+  });
+
+  describe("jsonToLuaTable (via inspectToolResponse)", () => {
+    let mockClient: ReturnType<typeof createMockClientSession>;
+    let clientsMap: Map<string, MCPClientSession>;
+
+    beforeEach(() => {
+      const mockTool: Tool = {
+        name: "test-tool",
+        description: "Test",
+        inputSchema: { type: "object" },
+      };
+      mockClient = createMockClientSession({ tools: [mockTool] });
+      clientsMap = new Map<string, MCPClientSession>([
+        ["server1", mockClient as unknown as MCPClientSession],
+      ]);
+      mockClientManager.getClientsBySession.mockReturnValue(clientsMap);
+      mockLuaRuntime.executeScript.mockResolvedValue({});
+    });
+
+    it("should convert simple object to Lua table", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { name: "test", value: 42 },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining('name = "test"'),
+        clientsMap,
+      );
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("value = 42"),
+        clientsMap,
+      );
+    });
+
+    it("should convert nested objects to Lua tables", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { nested: { inner: "value" } },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("nested = {"),
+        clientsMap,
+      );
+    });
+
+    it("should convert arrays to Lua tables", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { items: [1, 2, 3] },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("items = {1, 2, 3}"),
+        clientsMap,
+      );
+    });
+
+    it("should handle boolean values", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { enabled: true, disabled: false },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("enabled = true"),
+        clientsMap,
+      );
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("disabled = false"),
+        clientsMap,
+      );
+    });
+
+    it("should handle null values", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { nullValue: null },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("nullValue = null"),
+        clientsMap,
+      );
+    });
+
+    it("should use bracket notation for keys with special characters", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { "special-key": "value", "123key": "numeric" },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining('["special-key"] = "value"'),
+        clientsMap,
+      );
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining('["123key"] = "numeric"'),
+        clientsMap,
+      );
+    });
+
+    it("should handle empty objects", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        {},
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("({})"),
+        clientsMap,
+      );
+    });
+
+    it("should handle arrays of objects", async () => {
+      await service.inspectToolResponse(
+        "server1",
+        "test_tool",
+        { users: [{ id: 1 }, { id: 2 }] },
+        "session-123",
+      );
+
+      expect(mockLuaRuntime.executeScript).toHaveBeenCalledWith(
+        expect.stringContaining("users = {{id = 1}, {id = 2}}"),
+        clientsMap,
+      );
+    });
+  });
+});
+
+// Helper function to create mock client sessions
+function createMockClientSession(options: {
+  serverVersion?: { name?: string; version?: string; description?: string };
+  instructions?: string;
+  tools?: Tool[];
+}): {
+  getServerVersion: ReturnType<typeof vi.fn>;
+  getInstructions: ReturnType<typeof vi.fn>;
+  listTools: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getServerVersion: vi.fn().mockReturnValue(options.serverVersion ?? {}),
+    getInstructions: vi.fn().mockReturnValue(options.instructions),
+    listTools: vi.fn().mockResolvedValue(options.tools ?? []),
+  };
+}


### PR DESCRIPTION
Add comprehensive test coverage for the three aggregation services
that were previously untested:

- ToolDiscoveryService (34 tests): covers listServers, listServerTools,
  getToolDetails, inspectToolResponse, and jsonToLuaTable conversion
- PromptAggregationService (23 tests): covers listPrompts, getPrompt,
  handlePromptListChanged, caching, and error handling
- ResourceAggregationService (25 tests): covers listResources, readResource,
  handleResourceListChanged, URI namespacing, and caching

These services are critical for aggregating data from multiple MCP servers
and now have proper unit test coverage for edge cases, error handling,
and caching behavior.