### PR TITLE
chore: clarify resource tool descriptions to specify gateway-proxy scope

### DIFF
--- a/apps/gateway/src/tools/list-resources-tool.ts
+++ b/apps/gateway/src/tools/list-resources-tool.ts
@@ -16,12 +16,12 @@ import { parseResourceUri } from "@my-cool-proxy/mcp-utilities";
 export class ListResourcesTool implements ITool {
   readonly name = "list-resources";
   readonly description =
-    "List available resources from configured MCP servers. " +
-    "Each returned resource will include all standard MCP resource fields plus a 'server' field " +
-    "indicating which server the resource belongs to.\n\n" +
+    "Lists gateway-proxied resources from upstream MCP servers. Returns only resources that are accessible " +
+    "through this gateway instance. Each resource includes a namespaced URI (gw:// or gw-skill:// scheme) " +
+    "that can be passed to read-resource.\n\n" +
     "Parameters:\n" +
     "- server (optional): The name of a specific MCP server to get resources from. If not provided, " +
-    "resources from all servers will be returned.";
+    "resources from all connected servers will be returned.";
   readonly schema = {};
 
   constructor(

--- a/apps/gateway/src/tools/read-resource-tool.ts
+++ b/apps/gateway/src/tools/read-resource-tool.ts
@@ -17,10 +17,10 @@ import { ResourceAggregationService } from "@my-cool-proxy/mcp-aggregation";
 export class ReadResourceTool implements ITool {
   readonly name = "read-resource";
   readonly description =
-    "Reads a specific resource from an MCP server, identified by server name and resource URI.\n\n" +
+    "Reads a gateway-proxied resource by its namespaced URI. Only supports URIs with gw:// or gw-skill:// schemes " +
+    "(as returned by list-resources). Routes the request to the appropriate upstream MCP server and returns the content.\n\n" +
     "Parameters:\n" +
-    "- server (required): The name of the MCP server from which to read the resource\n" +
-    "- uri (required): The URI of the resource to read";
+    "- uri (required): The namespaced resource URI (e.g., gw://server-name/original-uri or gw-skill://skill-name/resource-path)";
   readonly schema = {
     uri: z
       .string()


### PR DESCRIPTION
Updated read-resource and list-resources tool descriptions to explicitly
state they only work with gateway-proxied resources:

- read-resource: Now clarifies it only supports gw:// and gw-skill:// URI
  schemes and routes requests to upstream MCP servers
- list-resources: Now specifies it returns only gateway-proxied resources
  with namespaced URIs

This helps differentiate these tools from any native resource tools that
agents like Claude Code may have built-in.