### PR TITLE
docs: update design docs for recent implementation changes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -891,6 +891,80 @@ Keep filesystem disabled (default) when:
 - Running untrusted or experimental agents
 - Minimizing attack surface
 
+### ACP Permission Auto-Approval
+
+The `allowOwnTools` option controls automatic permission approval for ACP agent tool calls based on tool kind.
+
+```json
+{
+  "acp": {
+    "agent": {
+      "command": "npx",
+      "args": ["@zed-industries/claude-code-acp"]
+    },
+    "allowOwnTools": {
+      "toolKinds": ["read", "search", "think"]
+    }
+  }
+}
+```
+
+- **allowOwnTools** (object, optional): Configuration for auto-approving tool permissions
+  - **dangerouslyAllowAll** (boolean, optional): Auto-approve ALL permission requests. **DANGEROUS** - bypasses all safety checks. Default: `false`
+  - **toolKinds** (array, optional): List of tool kinds to auto-approve. Default: `[]`
+
+#### Valid Tool Kinds
+
+| Tool Kind     | Description                                 |
+| ------------- | ------------------------------------------- |
+| `read`        | Reading files or data                       |
+| `edit`        | Modifying existing content                  |
+| `delete`      | Removing files or data                      |
+| `move`        | Moving or renaming files                    |
+| `search`      | Searching through content                   |
+| `execute`     | Running commands or scripts                 |
+| `think`       | Internal reasoning/planning operations      |
+| `fetch`       | Network requests or external data retrieval |
+| `switch_mode` | Changing operational modes                  |
+| `other`       | Uncategorized operations                    |
+
+#### Permission Check Priority
+
+Permission requests are evaluated in this order:
+
+1. **dangerouslyAllowAll** - If true, immediately approve (supersedes all other checks)
+2. **toolKinds** - If tool's kind is in the list, approve
+3. **Sidecar tool tag** - If tool name contains the session's sidecar tag, approve (for sampling-with-tools flow)
+4. **Default deny** - All other requests are denied
+
+#### Example Configurations
+
+**Read-only agent** (safe for exploration):
+
+```json
+{
+  "acp": {
+    "allowOwnTools": {
+      "toolKinds": ["read", "search", "think"]
+    }
+  }
+}
+```
+
+**Full-access agent** (for trusted environments):
+
+```json
+{
+  "acp": {
+    "allowOwnTools": {
+      "dangerouslyAllowAll": true
+    }
+  }
+}
+```
+
+See [Sampling - ACP Permission Auto-Approval](./design/sampling.md#acp-permission-auto-approval) for detailed architecture.
+
 ## Session Persistence (HTTP Mode)
 
 In HTTP mode, the gateway automatically persists session state to SQLite, enabling session resumability across server restarts. This is always enabled with zero configuration required.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -138,14 +138,14 @@ sequenceDiagram
 
 ## Key Components
 
-| Component      | File                                | Purpose                                   |
-| -------------- | ----------------------------------- | ----------------------------------------- |
-| Entry Point    | `src/index.ts`                      | Starts HTTP or stdio mode based on config |
-| DI Container   | `src/container/inversify.config.ts` | Wires all dependencies together           |
-| Gateway Server | `src/mcp/gateway-server.ts`         | Main MCP server, registers tools          |
-| Client Manager | `src/mcp/client-manager.ts`         | Manages upstream MCP connections          |
-| Lua Runtime    | `src/lua/runtime.ts`                | Executes user scripts                     |
-| Tool Discovery | `src/mcp/tool-discovery-service.ts` | Powers discovery tools                    |
+| Component      | File                                  | Purpose                                   |
+| -------------- | ------------------------------------- | ----------------------------------------- |
+| Entry Point    | `src/index.ts`                        | Starts HTTP or stdio mode based on config |
+| DI Container   | `src/container/inversify.config.ts`   | Wires all dependencies together           |
+| Gateway Server | `src/mcp/gateway-server.ts`           | Main MCP server, registers tools          |
+| Client Manager | `src/mcp/client-manager.ts`           | Manages upstream MCP connections          |
+| Lua Runtime    | `packages/lua-runtime/src/runtime.ts` | Executes user scripts                     |
+| Tool Discovery | `src/mcp/tool-discovery-service.ts`   | Powers discovery tools                    |
 
 ## Transport Modes
 

--- a/docs/design/progressive-discovery.md
+++ b/docs/design/progressive-discovery.md
@@ -113,7 +113,16 @@ Tools for calculator:
 - divide (Lua: divide): Divide two numbers
 ```
 
-**Implementation:** `src/tools/list-server-tools-tool.ts`
+**Note:** Tool names are preloaded in server instructions at gateway startup, so agents can see a summary of available tools without calling this tool. The gateway limits tool names to 40 per server in instructions, using an "(and X more)" suffix for larger tool sets.
+
+**Example instruction excerpt:**
+
+```
+## github-mcp-server
+Tools: get_file_contents, list_issues, list_pull_requests, create_issue, ... (and 47 more)
+```
+
+**Implementation:** `src/tools/list-server-tools-tool.ts` (discovery), `src/services/server-info-preloader.ts` (preloading, `MAX_TOOLS_IN_INSTRUCTIONS = 40`)
 
 ### 3. `tool-details`
 

--- a/docs/design/sampling.md
+++ b/docs/design/sampling.md
@@ -378,6 +378,82 @@ The original name is extracted when capturing, and that's what's returned in the
 | CreateMessageResult with tool_use | [Schema: CreateMessageResult](https://modelcontextprotocol.io/specification/2025-11-25/schema)            |
 | Server executes tools             | [SEP-1577: Sampling With Tools](https://modelcontextprotocol.io/community/seps/1577--sampling-with-tools) |
 
+## ACP Permission Auto-Approval
+
+When using the ACP shim, the gateway can auto-approve permission requests from the agent based on tool kind. This provides fine-grained control over what actions the shim agent can perform.
+
+### AllowOwnToolsConfig Interface
+
+```typescript
+interface AllowOwnToolsConfig {
+  /**
+   * DANGEROUS: Auto-approve ALL permission requests regardless of tool kind.
+   * Supersedes toolKinds if set to true.
+   * Default: false
+   */
+  dangerouslyAllowAll?: boolean;
+
+  /**
+   * List of tool kinds to auto-approve.
+   * Default: [] (no auto-approval by kind)
+   */
+  toolKinds?: ToolKind[];
+}
+```
+
+### Valid Tool Kinds
+
+| Tool Kind     | Description                                 |
+| ------------- | ------------------------------------------- |
+| `read`        | Reading files or data                       |
+| `edit`        | Modifying existing content                  |
+| `delete`      | Removing files or data                      |
+| `move`        | Moving or renaming files                    |
+| `search`      | Searching through content                   |
+| `execute`     | Running commands or scripts                 |
+| `think`       | Internal reasoning/planning operations      |
+| `fetch`       | Network requests or external data retrieval |
+| `switch_mode` | Changing operational modes                  |
+| `other`       | Uncategorized operations                    |
+
+### Permission Check Priority
+
+Permission requests are evaluated in this order:
+
+1. **dangerouslyAllowAll** - If true, approve immediately
+2. **toolKinds** - If tool kind is in the list, approve
+3. **Sidecar tool tag** - If tool name contains the session's sidecar tag, approve
+4. **Default deny** - All other requests are denied
+
+```mermaid
+flowchart TB
+    Request["Permission Request"] --> DangerCheck{"dangerouslyAllowAll?"}
+    DangerCheck -->|Yes| Approve["✓ APPROVE"]
+    DangerCheck -->|No| KindCheck{"toolKind in\ntoolKinds[]?"}
+    KindCheck -->|Yes| Approve
+    KindCheck -->|No| TagCheck{"Has sidecar\ntool tag?"}
+    TagCheck -->|Yes| Approve
+    TagCheck -->|No| Deny["✗ DENY"]
+```
+
+### Example Configuration
+
+```json
+{
+  "acp": {
+    "agent": {
+      "command": "npx",
+      "args": ["@zed-industries/claude-code-acp"]
+    },
+    "allowOwnTools": {
+      "toolKinds": ["read", "search", "think"]
+    }
+  }
+}
+```
+
+Implementation in `packages/acp-client/src/acp-client.ts`.
+
 ## Configuration
 
 ### Enabling Sampling Per-Server
@@ -436,6 +512,7 @@ Native client sampling always takes priority over the shim.
 | `apps/gateway/src/handlers/proxy-handlers.ts`       | Handler registration logic                    |
 | `packages/acp-client/src/acp-client.ts`             | Permission handler with tool call capture     |
 | `packages/acp-client/src/acp-client-session.ts`     | Exposes getCapturedToolCall() to shim         |
+| `packages/acp-client/src/types.ts`                  | AllowOwnToolsConfig interface                 |
 | `packages/mcp-client/src/client-manager.ts`         | Capability advertising                        |
 | `packages/mcp-sampling-sidecar/src/index.ts`        | Exposes tools to agent, handles capture       |
 

--- a/docs/design/session-management.md
+++ b/docs/design/session-management.md
@@ -78,8 +78,29 @@ classDiagram
         +getServer()
     }
 
+    class SQLiteDatabase {
+        -db: Database
+        +getDatabase()
+        +transaction(fn)
+        +close()
+    }
+
+    class SQLiteCapabilityStore {
+        +setCapabilities(sessionId, caps)
+        +getCapabilities(sessionId)
+        +setWorkingDirectory(sessionId, path)
+        +getWorkingDirectory(sessionId)
+    }
+
+    class SQLiteEventStore {
+        +storeEvent(eventId, streamId, message)
+        +getEventsAfter(lastEventId)
+    }
+
     MCPClientManager "1" --> "*" MCPClientSession
     MCPGatewayServer --> MCPClientManager
+    SQLiteCapabilityStore --> SQLiteDatabase
+    SQLiteEventStore --> SQLiteDatabase
 ```
 
 ## Session Lifecycle (HTTP Mode)
@@ -250,21 +271,114 @@ sequenceDiagram
     Gateway->>Agent: sendPromptListChanged()
 ```
 
+### Logging Message Forwarding
+
+The gateway forwards `notifications/message` (logging) notifications from upstream servers to downstream clients. The gateway advertises the "logging" capability to upstream servers.
+
+**Source Identification**: Log messages are prefixed with `[server-name]` so downstream clients can identify which upstream server generated the log:
+
+```
+Original logger: "database"
+Forwarded logger: "[postgres-server] database"
+```
+
+Implementation in `packages/mcp-client/src/client-session.ts`:
+
+```typescript
+const prefixedLogger = originalLogger
+  ? `[${this.serverName}] ${originalLogger}`
+  : `[${this.serverName}]`;
+```
+
+## Session Persistence (HTTP Mode)
+
+In HTTP mode, session state is automatically persisted to SQLite, enabling session resumability across server restarts.
+
+### SQLite Components
+
+| Component               | Purpose                                              |
+| ----------------------- | ---------------------------------------------------- |
+| `SQLiteDatabase`        | Database connection and schema management            |
+| `SQLiteCapabilityStore` | Persists client capabilities and working directories |
+| `SQLiteEventStore`      | Persists SSE events for resumability                 |
+
+### Database Location
+
+Session data is stored at platform-specific locations:
+
+| Platform    | Path                                                      |
+| ----------- | --------------------------------------------------------- |
+| **Linux**   | `~/.local/share/my-cool-proxy/sessions.db`                |
+| **macOS**   | `~/Library/Application Support/my-cool-proxy/sessions.db` |
+| **Windows** | `%LOCALAPPDATA%\my-cool-proxy\Data\sessions.db`           |
+
+### Configuration
+
+- **WAL Mode**: Enabled for better concurrent access and crash recovery
+- **Event Retention**: 1000 events per session (FIFO eviction when exceeded)
+- **Session TTL**: 5 minutes (`SESSION_TTL_MS`) of inactivity before expiration
+
+### Implementation Files
+
+| File                                                 | Purpose                          |
+| ---------------------------------------------------- | -------------------------------- |
+| `apps/gateway/src/stores/sqlite-database.ts`         | Database connection wrapper      |
+| `apps/gateway/src/stores/sqlite-capability-store.ts` | Session capability persistence   |
+| `apps/gateway/src/stores/sqlite-event-store.ts`      | SSE event persistence            |
+| `apps/gateway/src/utils/db-paths.ts`                 | Platform-specific database paths |
+
+## Session Restoration
+
+When the gateway restarts, persisted sessions can be restored automatically.
+
+### onSessionRestored Callback
+
+The `onSessionRestored` callback handles session restoration:
+
+1. Triggered when a client reconnects with a previously-stored session ID
+2. Re-initializes upstream MCP client connections
+3. Blocks incoming requests until upstream servers are ready
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway
+    participant Upstream as Upstream Servers
+
+    Note over Client,Upstream: Server Restart
+    Client->>Gateway: Reconnect with existing session ID
+    Gateway->>Gateway: Restore session from SQLite
+    Gateway->>Gateway: onSessionRestored() triggered
+
+    loop For each configured server
+        Gateway->>Upstream: Reconnect MCP client
+        Upstream-->>Gateway: Connected
+    end
+
+    Gateway-->>Client: Session ready for requests
+```
+
+### SSE Event Resumability
+
+When clients reconnect, they can provide a `Last-Event-ID` header. The gateway replays events after that ID from the SQLite event store, ensuring no messages are lost during disconnections.
+
 ## Stdio Mode Differences
 
-| Aspect            | HTTP Mode                  | Stdio Mode            |
-| ----------------- | -------------------------- | --------------------- |
-| Session ID        | From header or generated   | Fixed "default"       |
-| Client init       | Lazy (on first request)    | Eager (at startup)    |
-| Multiple sessions | Yes                        | No                    |
-| Server factory    | `serveHttp()` with factory | `serveStdio()` direct |
-| Gateway instances | One per session            | Single instance       |
+| Aspect              | HTTP Mode                  | Stdio Mode            |
+| ------------------- | -------------------------- | --------------------- |
+| Session ID          | From header or generated   | Fixed "default"       |
+| Client init         | Lazy (on first request)    | Eager (at startup)    |
+| Multiple sessions   | Yes                        | No                    |
+| Server factory      | `serveHttp()` with factory | `serveStdio()` direct |
+| Gateway instances   | One per session            | Single instance       |
+| Session persistence | SQLite-backed              | Not used              |
 
 In stdio mode:
 
 - All clients initialized at startup via `serveStdio()`
 - Single gateway server connects to stdio transport
 - No session isolation needed
+- Session persistence is not used (single fixed session)
 
 ## Implementation Files
 

--- a/docs/design/transport-modes.md
+++ b/docs/design/transport-modes.md
@@ -60,6 +60,10 @@ sequenceDiagram
 | **Client Init** | MCP clients created lazily when a session first makes a request             |
 | **Transport**   | Streamable HTTP transport via `@karashiiro/mcp` abstraction                 |
 | **Endpoint**    | Single `/mcp` endpoint handles GET (SSE), POST (messages), DELETE (cleanup) |
+| **Persistence** | Session state persisted to SQLite; survives server restarts                 |
+| **Session TTL** | Sessions expire after 5 minutes of inactivity                               |
+
+See [Session Management - Session Persistence](./session-management.md#session-persistence-http-mode) for details on SQLite persistence.
 
 ### Session ID Handling
 


### PR DESCRIPTION
- Fix incorrect Lua runtime path in index.md
- Add SQLite session persistence and restoration docs to session-management.md
- Add logging message forwarding docs to session-management.md
- Add ACP permission auto-approval section to sampling.md
- Add ACP allowOwnTools configuration to configuration.md
- Add tool name preloading note to progressive-discovery.md
- Add SQLite persistence reference to transport-modes.md