### PR TITLE
feat(tools): add MCP spec annotations to gateway tools

### DIFF
--- a/apps/gateway/src/mcp/gateway-server.ts
+++ b/apps/gateway/src/mcp/gateway-server.ts
@@ -160,6 +160,7 @@ export class MCPGatewayServer {
           description: tool.description,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           inputSchema: tool.schema as any,
+          annotations: tool.annotations,
         },
         async (
           args: Record<string, unknown>,

--- a/apps/gateway/src/tools/base-tool.ts
+++ b/apps/gateway/src/tools/base-tool.ts
@@ -1,4 +1,7 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 
 /**
  * Context provided to tool execution
@@ -28,6 +31,12 @@ export interface ITool {
    * The JSON schema for the tool's input parameters
    */
   readonly schema: Record<string, unknown>;
+
+  /**
+   * Optional annotations providing hints about the tool's behavior.
+   * See MCP spec for details on each annotation field.
+   */
+  readonly annotations?: ToolAnnotations;
 
   /**
    * Execute the tool with the given arguments and context

--- a/apps/gateway/src/tools/execute-lua-tool.ts
+++ b/apps/gateway/src/tools/execute-lua-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod";
 import type {
@@ -62,6 +65,13 @@ export class ExecuteLuaTool implements ITool {
       .describe(
         "Lua script to execute. See tool description for syntax and workflow.",
       ),
+  };
+  readonly annotations: ToolAnnotations = {
+    title: "Execute Lua Script",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
   };
 
   constructor(

--- a/apps/gateway/src/tools/inspect-tool-response-tool.ts
+++ b/apps/gateway/src/tools/inspect-tool-response-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
@@ -46,6 +49,13 @@ export class InspectToolResponseTool implements ITool {
         "Minimal arguments for the sample call (e.g., {limit: 1} for pagination). " +
           "Use the smallest/cheapest request possible to understand the response structure.",
       ),
+  };
+  readonly annotations: ToolAnnotations = {
+    title: "Inspect Tool Response",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
   };
 
   constructor(

--- a/apps/gateway/src/tools/invoke-gateway-skill-script-tool.ts
+++ b/apps/gateway/src/tools/invoke-gateway-skill-script-tool.ts
@@ -3,7 +3,10 @@ import * as z from "zod";
 import { spawn } from "child_process";
 import { resolve, sep } from "path";
 import { existsSync, statSync } from "fs";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { getErrorMessage } from "@my-cool-proxy/mcp-utilities";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
@@ -37,6 +40,13 @@ export class InvokeGatewaySkillScriptTool implements ITool {
       .array(z.string())
       .optional()
       .describe("Optional arguments to pass to the script"),
+  };
+  readonly annotations: ToolAnnotations = {
+    title: "Invoke Skill Script",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: true,
   };
 
   constructor(

--- a/apps/gateway/src/tools/list-resources-tool.ts
+++ b/apps/gateway/src/tools/list-resources-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
 import type { ITool, ToolExecutionContext } from "./base-tool.js";
@@ -24,6 +27,12 @@ export class ListResourcesTool implements ITool {
     "- server (optional): The name of a specific MCP server to get resources from. If not provided, " +
     "resources from all connected servers will be returned.";
   readonly schema = {};
+  readonly annotations: ToolAnnotations = {
+    title: "List MCP Resources",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  };
 
   constructor(
     @$inject(TYPES.ResourceAggregationService)

--- a/apps/gateway/src/tools/list-server-tools-tool.ts
+++ b/apps/gateway/src/tools/list-server-tools-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
 import type { ITool, ToolExecutionContext } from "./base-tool.js";
@@ -27,6 +30,12 @@ export class ListServerToolsTool implements ITool {
     luaServerName: luaServerNameSchema.describe(
       "The Lua identifier of the MCP server to list tools for",
     ),
+  };
+  readonly annotations: ToolAnnotations = {
+    title: "List Server Tools",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
   };
 
   constructor(

--- a/apps/gateway/src/tools/list-servers-tool.ts
+++ b/apps/gateway/src/tools/list-servers-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
 import type { ITool, ToolExecutionContext } from "./base-tool.js";
@@ -24,6 +27,12 @@ export class ListServersTool implements ITool {
     "capabilities you have access to. Returns server names with their Lua identifiers for use in " +
     "subsequent discovery (list-server-tools → tool-details → optionally inspect-tool-response) and execution.";
   readonly schema = {};
+  readonly annotations: ToolAnnotations = {
+    title: "List MCP Servers",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  };
 
   constructor(
     @$inject(TYPES.ToolDiscoveryService)

--- a/apps/gateway/src/tools/read-resource-tool.ts
+++ b/apps/gateway/src/tools/read-resource-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod";
 import { getErrorMessage } from "@my-cool-proxy/mcp-utilities";
 import { $inject } from "../container/decorators.js";
@@ -27,6 +30,12 @@ export class ReadResourceTool implements ITool {
     uri: z
       .string()
       .describe("The namespaced resource URI (as returned by list-resources)"),
+  };
+  readonly annotations: ToolAnnotations = {
+    title: "Read MCP Resource",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
   };
 
   constructor(

--- a/apps/gateway/src/tools/summary-stats-tool.ts
+++ b/apps/gateway/src/tools/summary-stats-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
 import type { ITool, ToolExecutionContext } from "./base-tool.js";
@@ -23,6 +26,12 @@ export class SummaryStatsTool implements ITool {
     "Get a quick summary of the gateway: total number of connected MCP servers, " +
     "and aggregate counts of tools, resources, and prompts across all servers.";
   readonly schema = {};
+  readonly annotations: ToolAnnotations = {
+    title: "Gateway Summary Statistics",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
+  };
 
   constructor(
     @$inject(TYPES.MCPClientManager) private clientPool: IMCPClientManager,

--- a/apps/gateway/src/tools/tool-details-tool.ts
+++ b/apps/gateway/src/tools/tool-details-tool.ts
@@ -1,5 +1,8 @@
 import { injectable } from "inversify";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
 import type { ITool, ToolExecutionContext } from "./base-tool.js";
@@ -26,6 +29,12 @@ export class ToolDetailsTool implements ITool {
   readonly schema = {
     luaServerName: luaServerNameSchema,
     luaToolName: luaToolNameSchema,
+  };
+  readonly annotations: ToolAnnotations = {
+    title: "Get Tool Details",
+    readOnlyHint: true,
+    idempotentHint: true,
+    openWorldHint: false,
   };
 
   constructor(

--- a/apps/gateway/src/tools/write-gateway-skill-tool.ts
+++ b/apps/gateway/src/tools/write-gateway-skill-tool.ts
@@ -3,7 +3,10 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { resolve, dirname } from "path";
 import { parse as parseYaml } from "yaml";
 import * as z from "zod";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CallToolResult,
+  ToolAnnotations,
+} from "@modelcontextprotocol/sdk/types.js";
 import { getErrorMessage } from "@my-cool-proxy/mcp-utilities";
 import { $inject } from "../container/decorators.js";
 import { TYPES } from "../types/index.js";
@@ -73,6 +76,13 @@ export class WriteGatewaySkillTool implements ITool {
         "Additional resource files to create or overwrite within the skill directory. " +
           "Typically stored in scripts/, references/, or assets/ subdirectories.",
       ),
+  };
+  readonly annotations: ToolAnnotations = {
+    title: "Write Gateway Skill",
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+    openWorldHint: false,
   };
 
   constructor(


### PR DESCRIPTION
- Add annotations field to ITool interface in base-tool.ts
- Wire annotations through gateway-server.ts registerTool()
- Add readOnly/destructive/idempotent/openWorld hints to all 10 tools