### PR TITLE
fix(ci): run actual server logic to catch post-install startup failures

### DIFF
--- a/.github/workflows/pack-test.yml
+++ b/.github/workflows/pack-test.yml
@@ -79,12 +79,13 @@ jobs:
           # Wait for server to initialize (imports all deps including pino)
           sleep 3
 
-          # Verify server is responding
-          curl --fail --silent --show-error http://localhost:3456/mcp > /dev/null || {
-            echo "Server failed to respond!"
+          # Verify server is responding (400 is fine - means server is up, just not a valid MCP request)
+          HTTP_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:3456/mcp)
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "Server failed to respond (connection refused)!"
             kill $SERVER_PID 2>/dev/null || true
             exit 1
-          }
+          fi
 
-          echo "Server started and responded successfully!"
+          echo "Server started and responded with HTTP $HTTP_CODE!"
           kill $SERVER_PID 2>/dev/null || true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,14 +87,15 @@ jobs:
           # Wait for server to initialize (imports all deps including pino)
           sleep 3
 
-          # Verify server is responding
-          curl --fail --silent --show-error http://localhost:3456/mcp > /dev/null || {
-            echo "Server failed to respond!"
+          # Verify server is responding (400 is fine - means server is up, just not a valid MCP request)
+          HTTP_CODE=$(curl --silent --output /dev/null --write-out "%{http_code}" http://localhost:3456/mcp)
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "Server failed to respond (connection refused)!"
             kill $SERVER_PID 2>/dev/null || true
             exit 1
-          }
+          fi
 
-          echo "Server started and responded successfully!"
+          echo "Server started and responded with HTTP $HTTP_CODE!"
           kill $SERVER_PID 2>/dev/null || true
 
       - name: Publish to npm


### PR DESCRIPTION
Avoids module-not-found issues like what happened (once again) with v1.3.0.