### PR TITLE
fix: handle dashboard port conflict gracefully instead of crashing gateway

### DIFF
--- a/apps/gateway/src/dashboard/dashboard-server.test.ts
+++ b/apps/gateway/src/dashboard/dashboard-server.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll } from "vitest";
 import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { createDashboardApp } from "./dashboard-server.js";
+import {
+  createDashboardApp,
+  startDashboardServer,
+} from "./dashboard-server.js";
 import { SQLiteDatabase } from "../stores/sqlite-database.js";
 import { SQLiteExecutionLog } from "../stores/sqlite-execution-log.js";
 import type { IMCPClientManager } from "@my-cool-proxy/mcp-client";
 import type {
   ICapabilityStore,
+  ILogger,
   LuaExecution,
   LuaToolCall,
   ToolUsage,
@@ -543,5 +548,46 @@ describe("Dashboard static file serving", () => {
     const body = await res.text();
     expect(body).toContain("<html>");
     expect(body).not.toContain("root:");
+  });
+});
+
+describe("startDashboardServer", () => {
+  it("should return undefined when port is already in use", async () => {
+    const blocker = createServer();
+    const port = await new Promise<number>((resolve) => {
+      blocker.listen(0, "localhost", () => {
+        resolve((blocker.address() as AddressInfo).port);
+      });
+    });
+
+    try {
+      const db = new SQLiteDatabase(":memory:");
+      const log = new SQLiteExecutionLog(db);
+      const warnings: string[] = [];
+
+      const result = await startDashboardServer({
+        executionLog: log,
+        clientManager: mockClientManager,
+        capabilityStore: mockCapabilityStore,
+        db,
+        config: { port, host: "localhost" },
+        staticDir: "/nonexistent",
+        logger: {
+          info: () => {},
+          warn: (_obj: unknown, msg?: string) => {
+            warnings.push(typeof _obj === "string" ? _obj : (msg ?? ""));
+          },
+          error: () => {},
+          debug: () => {},
+        } as unknown as ILogger,
+      });
+
+      expect(result).toBeUndefined();
+      expect(warnings.some((w) => w.includes("already in use"))).toBe(true);
+
+      db.close();
+    } finally {
+      blocker.close();
+    }
   });
 });

--- a/apps/gateway/src/dashboard/dashboard-server.ts
+++ b/apps/gateway/src/dashboard/dashboard-server.ts
@@ -196,7 +196,7 @@ export interface StartDashboardServerOptions {
 // eslint-disable-next-line max-lines-per-function
 export async function startDashboardServer(
   options: StartDashboardServerOptions,
-): Promise<DashboardHandle> {
+): Promise<DashboardHandle | undefined> {
   const {
     executionLog,
     clientManager,
@@ -220,6 +220,30 @@ export async function startDashboardServer(
     port,
     hostname: host,
   });
+
+  const bound = await new Promise<boolean>((resolve) => {
+    server.on("listening", () => resolve(true));
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        logger.warn(
+          { port, host },
+          `Dashboard port ${port} is already in use — skipping dashboard. ` +
+            `Another gateway instance may be holding this port.`,
+        );
+      } else {
+        logger.warn(
+          { port, host, error: err.message },
+          `Dashboard failed to start: ${err.message}`,
+        );
+      }
+      resolve(false);
+    });
+  });
+
+  if (!bound) {
+    server.close();
+    return undefined;
+  }
 
   // WebSocket server
   const wss = new WebSocketServer({ noServer: true });


### PR DESCRIPTION
## Summary

When the gateway is configured globally (e.g. in `~/.claude.json` `mcpServers`), every Claude Code session spawns its own proxy instance. The second instance crashes with `EADDRINUSE` when the dashboard tries to bind port 3100 — which is already held by the first instance.

The crash is silent and confusing: it happens **after** the MCP `initialize` response (so the client sees server instructions) but **before** `tools/list` can be served (so no tools appear). From the user's perspective, the proxy looks "connected but broken" — instructions load, but `list-servers`, `execute`, etc. are missing entirely.

This PR makes the dashboard bind failure non-fatal:
- Wait for `listening` / `error` events after `serve()` before continuing
- On `EADDRINUSE` (or any bind error), log a warning and return `undefined`
- The callers (`maybeStartDashboard`) already handle `undefined` — the gateway continues without the dashboard

The gateway's core MCP proxy functionality is completely unaffected by the dashboard being unavailable.

## Changes

- **`dashboard-server.ts`**: Changed `startDashboardServer` return type to `Promise<DashboardHandle | undefined>`. Added a `listening`/`error` event check after `serve()` to detect bind failures before proceeding with WebSocket setup.
- **`dashboard-server.test.ts`**: Added test that occupies a port with a TCP server, then verifies `startDashboardServer` returns `undefined` and logs an appropriate warning instead of throwing.

## Reproduction

1. Configure `my-cool-proxy` in `~/.claude.json` global `mcpServers`
2. Open two Claude Code sessions simultaneously
3. In the second session, the proxy's MCP tools (`list-servers`, `execute`, etc.) are missing — only instructions load
4. The gateway log for the second instance shows no `Downstream client initialized` message (the process dies before reaching that point)

## Test plan

- [x] All 1202 existing unit tests pass
- [x] New test verifies `EADDRINUSE` returns `undefined` with warning log
- [ ] Manual: open two Claude Code sessions with global proxy config — second session should show "Dashboard port 3100 is already in use — skipping dashboard" in logs and tools should work normally